### PR TITLE
Fix: 修复InteractBlockWithItemCriteria在未交互时也触发的问题

### DIFF
--- a/languages/en/criteria.yml
+++ b/languages/en/criteria.yml
@@ -256,7 +256,7 @@ criteria:
     - name: Farm Land
       difficulty: very_hard
       block: grass_block, dirt
-      item: wooden_hoe, stone_hoe, copper_hoe, iron_hoe, golden_hoe, diamond_hoe, netherite_hoe
+      item: wooden_hoe, stone_hoe, iron_hoe, golden_hoe, diamond_hoe, netherite_hoe
   # Triggers when player dropped any matching *item*
   drop_item:
     - name: Drop Item

--- a/languages/en/criteria.yml
+++ b/languages/en/criteria.yml
@@ -240,9 +240,11 @@ criteria:
     - name: Open Furnace
       difficulty: easy
       block: furnace
+      item: "*"
     - name: Open Chest
       difficulty: normal
       block: chest, trapped_chest
+      item: "*"
     - name: Open Crafting Table With Stone Pickaxe In Hand
       difficulty: hard
       block: crafting_table

--- a/languages/en/criteria.yml
+++ b/languages/en/criteria.yml
@@ -254,6 +254,7 @@ criteria:
     - name: Farm Land
       difficulty: very_hard
       block: grass_block, dirt
+      item: wooden_hoe, stone_hoe, copper_hoe, iron_hoe, golden_hoe, diamond_hoe, netherite_hoe
   # Triggers when player dropped any matching *item*
   drop_item:
     - name: Drop Item

--- a/languages/zh-cn/criteria.yml
+++ b/languages/zh-cn/criteria.yml
@@ -238,9 +238,11 @@ criteria:
     - name: 打开熔炉
       difficulty: easy
       block: furnace
+      item: "*"
     - name: 打开箱子
       difficulty: normal
       block: chest, trapped_chest
+      item: "*"
     - name: 手持石镐打开工作台
       difficulty: hard
       block: crafting_table

--- a/languages/zh-cn/criteria.yml
+++ b/languages/zh-cn/criteria.yml
@@ -252,6 +252,7 @@ criteria:
     - name: 用锄头耕地
       difficulty: very_hard
       block: grass_block, dirt
+      item: wooden_hoe, stone_hoe, copper_hoe, iron_hoe, golden_hoe, diamond_hoe, netherite_hoe
   # 丢出item时触发
   drop_item:
     - name: 丢弃物品

--- a/languages/zh-cn/criteria.yml
+++ b/languages/zh-cn/criteria.yml
@@ -254,7 +254,7 @@ criteria:
     - name: 用锄头耕地
       difficulty: very_hard
       block: grass_block, dirt
-      item: wooden_hoe, stone_hoe, copper_hoe, iron_hoe, golden_hoe, diamond_hoe, netherite_hoe
+      item: wooden_hoe, stone_hoe, iron_hoe, golden_hoe, diamond_hoe, netherite_hoe
   # 丢出item时触发
   drop_item:
     - name: 丢弃物品

--- a/src/main/kotlin/net/astrorbits/dontdoit/criteria/InteractBlockWithItemCriteria.kt
+++ b/src/main/kotlin/net/astrorbits/dontdoit/criteria/InteractBlockWithItemCriteria.kt
@@ -55,9 +55,14 @@ class InteractBlockWithItemCriteria : Criteria(), Listener, BlockInspectCandidat
         val block = event.clickedBlock ?: return
         val item = event.item ?: ItemStack.empty()
 
-        // if (event.useInteractedBlock() == Event.Result.DENY) return // 避免潜行放方块时也触发
+        // if (event.useInteractedBlock() == Event.Result.DENY) return // 666神秘上游永远返回ALLOW诗人握持
+        // 更改实现方法
         val player = event.player
-        if (player.isSneaking && item.type.isBlock) return //更改实现方法
+        val wouldPlace = player.isSneaking &&              // 潜行
+                item.type.isBlock &&              // 手上是可放置方块
+                event.blockFace != null &&        // 有明确点击面
+                block.type.isInteractable          // 方块本身能交互（箱子、工作台…）
+        if (wouldPlace) return                             // 如果是“放置”动作，跳过检测
 
         if ((isBlockWildcard || block.type in blockTypes) &&
             (isItemWildcard || item.type in itemTypes)

--- a/src/main/kotlin/net/astrorbits/dontdoit/criteria/InteractBlockWithItemCriteria.kt
+++ b/src/main/kotlin/net/astrorbits/dontdoit/criteria/InteractBlockWithItemCriteria.kt
@@ -55,7 +55,9 @@ class InteractBlockWithItemCriteria : Criteria(), Listener, BlockInspectCandidat
         val block = event.clickedBlock ?: return
         val item = event.item ?: ItemStack.empty()
 
-        if (event.useInteractedBlock() == Event.Result.DENY) return // 避免潜行放方块时也触发
+        // if (event.useInteractedBlock() == Event.Result.DENY) return // 避免潜行放方块时也触发
+        val player = event.player
+        if (player.isSneaking && item.type.isBlock) return //更改实现方法
 
         if ((isBlockWildcard || block.type in blockTypes) &&
             (isItemWildcard || item.type in itemTypes)

--- a/src/main/kotlin/net/astrorbits/dontdoit/criteria/InteractBlockWithItemCriteria.kt
+++ b/src/main/kotlin/net/astrorbits/dontdoit/criteria/InteractBlockWithItemCriteria.kt
@@ -6,6 +6,7 @@ import net.astrorbits.dontdoit.criteria.inspect.InventoryInspectContext
 import net.astrorbits.dontdoit.criteria.inspect.InventoryItemInspectCandidate
 import net.astrorbits.dontdoit.system.team.TeamData
 import org.bukkit.Material
+import org.bukkit.event.Event
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.block.Action
@@ -53,6 +54,9 @@ class InteractBlockWithItemCriteria : Criteria(), Listener, BlockInspectCandidat
         if (event.action != Action.RIGHT_CLICK_BLOCK) return
         val block = event.clickedBlock ?: return
         val item = event.item ?: ItemStack.empty()
+
+        if (event.useInteractedBlock() == Event.Result.DENY) return // 避免潜行放方块时也触发
+
         if ((isBlockWildcard || block.type in blockTypes) &&
             (isItemWildcard || item.type in itemTypes)
         ) {

--- a/src/main/kotlin/net/astrorbits/dontdoit/criteria/InteractBlockWithItemCriteria.kt
+++ b/src/main/kotlin/net/astrorbits/dontdoit/criteria/InteractBlockWithItemCriteria.kt
@@ -70,8 +70,6 @@ class InteractBlockWithItemCriteria : Criteria(), Listener, BlockInspectCandidat
         val block = event.clickedBlock ?: return
         val item = event.item ?: ItemStack.empty()
 
-        // if (event.useInteractedBlock() == Event.Result.DENY) return // 666神秘上游永远返回ALLOW诗人握持
-
         val player = event.player
         val handItem = event.item ?: ItemStack.empty()
         val targetBlock = event.clickedBlock ?: return
@@ -94,9 +92,6 @@ class InteractBlockWithItemCriteria : Criteria(), Listener, BlockInspectCandidat
         // 允许 Paper 的潜行空手交互被触发
         event.setUseInteractedBlock(Event.Result.ALLOW)
         event.setUseItemInHand(Event.Result.ALLOW)
-
-
-        // if (player.isSneaking && item.type.isBlock) return // 更改实现方法
 
         if ((isBlockWildcard || block.type in blockTypes) &&
             (isItemWildcard || item.type in itemTypes)

--- a/src/main/kotlin/net/astrorbits/dontdoit/criteria/InteractBlockWithItemCriteria.kt
+++ b/src/main/kotlin/net/astrorbits/dontdoit/criteria/InteractBlockWithItemCriteria.kt
@@ -56,13 +56,8 @@ class InteractBlockWithItemCriteria : Criteria(), Listener, BlockInspectCandidat
         val item = event.item ?: ItemStack.empty()
 
         // if (event.useInteractedBlock() == Event.Result.DENY) return // 666神秘上游永远返回ALLOW诗人握持
-        // 更改实现方法
         val player = event.player
-        val wouldPlace = player.isSneaking &&              // 潜行
-                item.type.isBlock &&              // 手上是可放置方块
-                event.blockFace != null &&        // 有明确点击面
-                block.type.isInteractable          // 方块本身能交互（箱子、工作台…）
-        if (wouldPlace) return                             // 如果是“放置”动作，跳过检测
+        if (player.isSneaking && item.type.isBlock) return //更改实现方法
 
         if ((isBlockWildcard || block.type in blockTypes) &&
             (isItemWildcard || item.type in itemTypes)

--- a/src/main/kotlin/net/astrorbits/dontdoit/criteria/InteractBlockWithItemCriteria.kt
+++ b/src/main/kotlin/net/astrorbits/dontdoit/criteria/InteractBlockWithItemCriteria.kt
@@ -5,13 +5,18 @@ import net.astrorbits.dontdoit.criteria.inspect.BlockInspectCandidate
 import net.astrorbits.dontdoit.criteria.inspect.InventoryInspectContext
 import net.astrorbits.dontdoit.criteria.inspect.InventoryItemInspectCandidate
 import net.astrorbits.dontdoit.system.team.TeamData
+import org.bukkit.Bukkit
 import org.bukkit.Material
 import org.bukkit.event.Event
 import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
 import org.bukkit.event.block.Action
+import org.bukkit.event.block.BlockPlaceEvent
 import org.bukkit.event.player.PlayerInteractEvent
 import org.bukkit.inventory.ItemStack
+import org.bukkit.plugin.java.JavaPlugin
+import java.util.UUID
 import kotlin.math.max
 
 class InteractBlockWithItemCriteria : Criteria(), Listener, BlockInspectCandidate, InventoryItemInspectCandidate {
@@ -48,16 +53,35 @@ class InteractBlockWithItemCriteria : Criteria(), Listener, BlockInspectCandidat
             this.isItemWildcard = isWildcard
         }
     }
+    private val recentBlockPlacers = mutableSetOf<UUID>()
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    fun onBlockPlace(event: BlockPlaceEvent) {
+        recentBlockPlacers += event.player.uniqueId
+        val providingPlugin = JavaPlugin.getProvidingPlugin(InteractBlockWithItemCriteria::class.java)
+
+        Bukkit.getScheduler().runTaskLater(providingPlugin, Runnable {
+            recentBlockPlacers -= event.player.uniqueId
+        }, 1L)
+    }
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = false)
     fun onInteractWithBlock(event: PlayerInteractEvent) {
         if (event.action != Action.RIGHT_CLICK_BLOCK) return
         val block = event.clickedBlock ?: return
         val item = event.item ?: ItemStack.empty()
 
         // if (event.useInteractedBlock() == Event.Result.DENY) return // 666神秘上游永远返回ALLOW诗人握持
+
         val player = event.player
-        if (player.isSneaking && item.type.isBlock) return //更改实现方法
+        // 排除“刚放置方块”的情况
+        if (player.uniqueId in recentBlockPlacers) return
+
+        // 允许 Paper 的潜行空手交互被触发
+        event.setUseInteractedBlock(Event.Result.ALLOW)
+        event.setUseItemInHand(Event.Result.ALLOW)
+
+
+        // if (player.isSneaking && item.type.isBlock) return // 更改实现方法
 
         if ((isBlockWildcard || block.type in blockTypes) &&
             (isItemWildcard || item.type in itemTypes)

--- a/src/main/kotlin/net/astrorbits/dontdoit/criteria/InteractBlockWithItemCriteria.kt
+++ b/src/main/kotlin/net/astrorbits/dontdoit/criteria/InteractBlockWithItemCriteria.kt
@@ -73,6 +73,21 @@ class InteractBlockWithItemCriteria : Criteria(), Listener, BlockInspectCandidat
         // if (event.useInteractedBlock() == Event.Result.DENY) return // 666神秘上游永远返回ALLOW诗人握持
 
         val player = event.player
+        val handItem = event.item ?: ItemStack.empty()
+        val targetBlock = event.clickedBlock ?: return
+        val face = event.blockFace
+
+        if (player.isSneaking &&
+            !handItem.type.isAir &&
+            handItem.type.isBlock
+        ) {
+            val against = targetBlock.getRelative(face)
+            // 空气 || 非固体（即可替换）
+            if (against.type.isAir || !against.type.isSolid) {
+                return   // 这会变成放置，不是交互，跳过
+            }
+        }
+
         // 排除“刚放置方块”的情况
         if (player.uniqueId in recentBlockPlacers) return
 

--- a/src/main/resources/criteria.yml
+++ b/src/main/resources/criteria.yml
@@ -238,9 +238,11 @@ criteria:
     - name: 打开熔炉
       difficulty: easy
       block: furnace
+      item: "*"
     - name: 打开箱子
       difficulty: normal
       block: chest, trapped_chest
+      item: "*"
     - name: 手持石镐打开工作台
       difficulty: hard
       block: crafting_table

--- a/src/main/resources/criteria.yml
+++ b/src/main/resources/criteria.yml
@@ -252,6 +252,7 @@ criteria:
     - name: 用锄头耕地
       difficulty: very_hard
       block: grass_block, dirt
+      item: wooden_hoe, stone_hoe, copper_hoe, iron_hoe, golden_hoe, diamond_hoe, netherite_hoe
   # 丢出item时触发
   drop_item:
     - name: 丢弃物品

--- a/src/main/resources/criteria.yml
+++ b/src/main/resources/criteria.yml
@@ -254,7 +254,7 @@ criteria:
     - name: 用锄头耕地
       difficulty: very_hard
       block: grass_block, dirt
-      item: wooden_hoe, stone_hoe, copper_hoe, iron_hoe, golden_hoe, diamond_hoe, netherite_hoe
+      item: wooden_hoe, stone_hoe, iron_hoe, golden_hoe, diamond_hoe, netherite_hoe
   # 丢出item时触发
   drop_item:
     - name: 丢弃物品


### PR DESCRIPTION
## 描述
修复 `InteractBlockWithItemCriteria` 在玩家**潜行放置方块**时仍误触发词条的问题，同时保证**空手/工具潜行右键容器**等正常交互可被检测。
以及修复了用锄头耕地词条item缺失的问题

## 问题现象
- 打开箱子等这一类的词条，在手持箱子（或任意可放置方块）对箱子潜行右键 **放置** 时，词条「打开箱子」被错误触发。 
- 用锄头耕地词条当玩家站在泥土或草方块上无条件触发 

## 解决方案
本PR采用双事件策略：  
1. 在 `PlayerInteractEvent(LOWEST)` 阶段精确识别「本次意图为放置」的玩家，写入临时 `WeakHashMap`；  
2. 在 `BlockPlaceEvent(MONITOR)` 成功放置后移除记录，防止残留；  
3. 正式检测逻辑中若玩家存在于集合则跳过，其余情况正常触发。

## 关于我是怎么发现这个BUG的
没人陪睦子米酱玩，睦子米酱只能和墨缇丝酱玩勒呜呜呜呜呜呜（
睦子米酱在和墨缇丝酱玩的时候随到了`用锄头耕地`词条，睦子米酱根本没有锄头还是触发了这个词条（哈气！
于是发现了同类词条下还有一些神秘BUG

另：记得改版本号
